### PR TITLE
Bug Fix: Correct quantity type to Decimal for fractional share trading

### DIFF
--- a/src/public_api_sdk/models/order.py
+++ b/src/public_api_sdk/models/order.py
@@ -23,9 +23,8 @@ class OrderValidationMixin:
     @field_validator("quantity")
     @classmethod
     def validate_quantity(cls, v: Optional[Decimal]) -> Optional[Decimal]:
-        if v is not None:
-            if v <= 0:
-                raise ValueError("`quantity` must be greater than 0")
+        if v is not None and v <= 0:
+            raise ValueError("`quantity` must be greater than 0")
         return v
 
     @field_validator("amount")


### PR DESCRIPTION
~~**Problem:** The SDK's `OrderRequest` and `PreflightRequest` models defined the `quantity `field as `Optional[int]`. This prevented users from placing orders for fractional share quantities (e.g., 0.1 shares), as attempting to pass a float would result in it being cast to `0`, failing the validation check (`quantity must be greater than 0`). The Public API documentation specifies that `quantity` should be a string and is used for fractional selling.~~

~~**Solution:** This PR modifies `src/public_api_sdk/models/order.py` to correctly handle fractional quantities:~~

~~- Changed the type hint for the `quantity` field in `OrderRequest` and `PreflightRequest` to `Optional[str]`.~~

~~- Updated the `validate_quantity` method in `OrderValidationMixin` to accept a string, validate it represents a positive number using `Decimal`, and return the string.~~

~~- Updated the `@field_serializer` for `quantity` to simply pass the string value through, as it's now the correct type.~~

~~This aligns the SDK with the API's expected input for fractional share quantities, allowing users to successfully place orders like `quantity="0.1"`.~~