### PR TITLE
Add option_details, previous_close, and on_day_change to Quote model

### DIFF
--- a/src/public_api_sdk/models/__init__.py
+++ b/src/public_api_sdk/models/__init__.py
@@ -3,6 +3,7 @@ from .account import Account, AccountType, AccountsResponse
 from .history import HistoryRequest, HistoryResponsePage
 from .instrument import Instrument, InstrumentsRequest, InstrumentsResponse, Trading
 from .instrument_type import InstrumentType
+from .greeks import GreekValues
 from .option import (
     OptionChainRequest,
     OptionChainResponse,
@@ -36,7 +37,7 @@ from .order import (
     EquityMarketSession,
 )
 from .portfolio import Portfolio
-from .quote import Quote, QuoteOutcome
+from .quote import ChainOptionDetails, Quote, QuoteOutcome
 from .subscription import (
     SubscriptionStatus,
     PriceChange,
@@ -66,6 +67,7 @@ __all__ = [
     "InstrumentsResponse",
     "InstrumentType",
     "Trading",
+    "GreekValues",
     "OptionChainRequest",
     "OptionChainResponse",
     "OptionExpirationsRequest",
@@ -81,6 +83,7 @@ __all__ = [
     "Order",
     "OrderStatus",
     "TimeInForce",
+    "ChainOptionDetails",
     "Quote",
     "QuoteOutcome",
     "PreflightRequest",

--- a/src/public_api_sdk/models/greeks.py
+++ b/src/public_api_sdk/models/greeks.py
@@ -1,0 +1,58 @@
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+class GreekValues(BaseModel):
+    """The actual Greek values for an option"""
+    delta: Decimal = Field(
+        ...,
+        description=(
+            "Delta is the theoretical estimate of how much an option's value "
+            "may change given a $1 move UP or DOWN in the underlying security. "
+            "The Delta values range from -1 to +1, with 0 representing an "
+            "option where the premium barely moves relative to price changes "
+            "in the underlying stock."
+        ),
+    )
+    gamma: Decimal = Field(
+        ...,
+        description=(
+            "Gamma represents the rate of change between an option's Delta and "
+            "the underlying asset's price. Higher Gamma values indicate that "
+            "the Delta could change dramatically with even very small price "
+            "changes in the underlying stock or fund."
+        ),
+    )
+    theta: Decimal = Field(
+        ...,
+        description=(
+            "Theta represents the rate of change between the option price and "
+            "time, or time sensitivity—sometimes known as an option's time "
+            "decay. Theta indicates the amount an option's price would "
+            "decrease as the time to expiration decreases, all else equal."
+        ),
+    )
+    vega: Decimal = Field(
+        ...,
+        description=(
+            "Vega measures the amount of increase or decrease in an option "
+            "premium based on a 1% change in implied volatility."
+        ),
+    )
+    rho: Decimal = Field(
+        ...,
+        description=(
+            "Rho represents the rate of change between an option's value and "
+            "a 1% change in the interest rate. This measures sensitivity to "
+            "the interest rate."
+        ),
+    )
+    implied_volatility: Decimal = Field(
+        ...,
+        alias="impliedVolatility",
+        description=(
+            "Implied volatility (IV) is a theoretical forecast of how volatile "
+            "an underlying stock is expected to be in the future."
+        ),
+    )

--- a/src/public_api_sdk/models/option.py
+++ b/src/public_api_sdk/models/option.py
@@ -357,59 +357,7 @@ class MultilegOrderResult(BaseModel):
     order_id: str = Field(..., alias="orderId")
 
 
-class GreekValues(BaseModel):
-    """The actual Greek values for an option"""
-    delta: Decimal = Field(
-        ...,
-        description=(
-            "Delta is the theoretical estimate of how much an option's value "
-            "may change given a $1 move UP or DOWN in the underlying security. "
-            "The Delta values range from -1 to +1, with 0 representing an "
-            "option where the premium barely moves relative to price changes "
-            "in the underlying stock."
-        ),
-    )
-    gamma: Decimal = Field(
-        ...,
-        description=(
-            "Gamma represents the rate of change between an option's Delta and "
-            "the underlying asset's price. Higher Gamma values indicate that "
-            "the Delta could change dramatically with even very small price "
-            "changes in the underlying stock or fund."
-        ),
-    )
-    theta: Decimal = Field(
-        ...,
-        description=(
-            "Theta represents the rate of change between the option price and "
-            "time, or time sensitivity—sometimes known as an option's time "
-            "decay. Theta indicates the amount an option's price would "
-            "decrease as the time to expiration decreases, all else equal."
-        ),
-    )
-    vega: Decimal = Field(
-        ...,
-        description=(
-            "Vega measures the amount of increase or decrease in an option "
-            "premium based on a 1% change in implied volatility."
-        ),
-    )
-    rho: Decimal = Field(
-        ...,
-        description=(
-            "Rho represents the rate of change between an option's value and "
-            "a 1% change in the interest rate. This measures sensitivity to "
-            "the interest rate."
-        ),
-    )
-    implied_volatility: Decimal = Field(
-        ...,
-        alias="impliedVolatility",
-        description=(
-            "Implied volatility (IV) is a theoretical forecast of how volatile "
-            "an underlying stock is expected to be in the future."
-        ),
-    )
+from .greeks import GreekValues  # noqa: E402 — re-exported for backwards compat
 
 
 class OptionGreeks(BaseModel):

--- a/src/public_api_sdk/models/quote.py
+++ b/src/public_api_sdk/models/quote.py
@@ -5,7 +5,31 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, AliasChoices
 
+from .greeks import GreekValues
 from .order import OrderInstrument
+
+
+class ChainOptionDetails(BaseModel):
+    """Option details returned inline in option chain responses.
+
+    This is distinct from the OptionDetails model in order.py, which represents
+    option metadata on order/preflight responses. The chain endpoint returns
+    strike price, mid-price, and full Greeks for each call/put entry.
+    """
+
+    model_config = {"populate_by_name": True}
+
+    strike_price: Optional[Decimal] = Field(
+        None,
+        validation_alias=AliasChoices("strike_price", "strikePrice"),
+        serialization_alias="strikePrice",
+    )
+    mid_price: Optional[Decimal] = Field(
+        None,
+        validation_alias=AliasChoices("mid_price", "midPrice"),
+        serialization_alias="midPrice",
+    )
+    greeks: Optional[GreekValues] = Field(None)
 
 
 class QuoteOutcome(str, Enum):
@@ -97,4 +121,25 @@ class Quote(BaseModel):
             "The total number of options contracts that are not closed or delivered"
             " on a particular day."
         ),
+    )
+    option_details: Optional[ChainOptionDetails] = Field(
+        None,
+        validation_alias=AliasChoices("option_details", "optionDetails"),
+        serialization_alias="optionDetails",
+        description=(
+            "Option details including strike price, mid-price, and Greeks."
+            " Present in option chain responses."
+        ),
+    )
+    previous_close: Optional[Decimal] = Field(
+        None,
+        validation_alias=AliasChoices("previous_close", "previousClose"),
+        serialization_alias="previousClose",
+        description="The previous closing price of the instrument.",
+    )
+    on_day_change: Optional[Decimal] = Field(
+        None,
+        validation_alias=AliasChoices("on_day_change", "onDayChange"),
+        serialization_alias="onDayChange",
+        description="The change in price on the current trading day.",
     )

--- a/tests/test_response_models.py
+++ b/tests/test_response_models.py
@@ -22,13 +22,14 @@ from public_api_sdk.models.history import (
 )
 from public_api_sdk.models.instrument import Instrument, InstrumentsResponse, Trading
 from public_api_sdk.models.instrument_type import InstrumentType
+from public_api_sdk.models.greeks import GreekValues
 from public_api_sdk.models.option import (
-    GreekValues,
     GreeksResponse,
+    OptionChainResponse,
     OptionGreeks,
 )
 from public_api_sdk.models.portfolio import BuyingPower, Portfolio, PortfolioPosition
-from public_api_sdk.models.quote import Quote, QuoteOutcome
+from public_api_sdk.models.quote import ChainOptionDetails, Quote, QuoteOutcome
 
 
 # ---------------------------------------------------------------------------
@@ -249,6 +250,145 @@ class TestQuoteDeserialization:
         }
         quote = Quote(**payload)
         assert quote.open_interest == 12345
+
+    def test_option_details_absent(self) -> None:
+        payload = {
+            "instrument": {"symbol": "AAPL", "type": "EQUITY"},
+            "outcome": "SUCCESS",
+        }
+        quote = Quote(**payload)
+        assert quote.option_details is None
+        assert quote.previous_close is None
+        assert quote.on_day_change is None
+
+    def test_option_details_with_greeks(self) -> None:
+        payload = {
+            "instrument": {"symbol": "SPY260409C00500000", "type": "OPTION"},
+            "outcome": "SUCCESS",
+            "bid": "158.59",
+            "ask": "161.40",
+            "optionDetails": {
+                "strikePrice": "500",
+                "midPrice": "160",
+                "greeks": {
+                    "delta": "0.9798",
+                    "gamma": "0.0005",
+                    "theta": "-2.3065",
+                    "vega": "0.0169",
+                    "rho": "0.0133",
+                    "impliedVolatility": "2.6706",
+                },
+            },
+            "previousClose": "159.00",
+            "onDayChange": "1.50",
+        }
+        quote = Quote(**payload)
+        assert isinstance(quote.option_details, ChainOptionDetails)
+        assert quote.option_details.strike_price == Decimal("500")
+        assert quote.option_details.mid_price == Decimal("160")
+        assert isinstance(quote.option_details.greeks, GreekValues)
+        assert quote.option_details.greeks.delta == Decimal("0.9798")
+        assert quote.option_details.greeks.gamma == Decimal("0.0005")
+        assert quote.option_details.greeks.theta == Decimal("-2.3065")
+        assert quote.option_details.greeks.vega == Decimal("0.0169")
+        assert quote.option_details.greeks.rho == Decimal("0.0133")
+        assert quote.option_details.greeks.implied_volatility == Decimal("2.6706")
+        assert quote.previous_close == Decimal("159.00")
+        assert quote.on_day_change == Decimal("1.50")
+
+    def test_option_details_without_greeks(self) -> None:
+        payload = {
+            "instrument": {"symbol": "SPY260409C00500000", "type": "OPTION"},
+            "outcome": "SUCCESS",
+            "optionDetails": {
+                "strikePrice": "500",
+                "midPrice": "160",
+            },
+        }
+        quote = Quote(**payload)
+        assert quote.option_details.strike_price == Decimal("500")
+        assert quote.option_details.greeks is None
+
+
+# ---------------------------------------------------------------------------
+# OptionChainResponse
+# ---------------------------------------------------------------------------
+
+
+class TestOptionChainResponseDeserialization:
+    def test_full_chain_response(self) -> None:
+        """Realistic option chain payload preserves optionDetails and greeks."""
+        greeks = {
+            "delta": "0.52",
+            "gamma": "0.015",
+            "theta": "-0.04",
+            "vega": "0.18",
+            "rho": "0.08",
+            "impliedVolatility": "0.30",
+        }
+        payload = {
+            "baseSymbol": "SPY",
+            "calls": [
+                {
+                    "instrument": {"symbol": "SPY260409C00500000", "type": "OPTION"},
+                    "outcome": "SUCCESS",
+                    "bid": "158.59",
+                    "ask": "161.40",
+                    "optionDetails": {
+                        "strikePrice": "500",
+                        "midPrice": "160",
+                        "greeks": greeks,
+                    },
+                    "previousClose": "159.00",
+                    "onDayChange": "1.50",
+                }
+            ],
+            "puts": [
+                {
+                    "instrument": {"symbol": "SPY260409P00500000", "type": "OPTION"},
+                    "outcome": "SUCCESS",
+                    "bid": "0.01",
+                    "ask": "0.03",
+                    "optionDetails": {
+                        "strikePrice": "500",
+                        "midPrice": "0.02",
+                        "greeks": greeks,
+                    },
+                }
+            ],
+        }
+        response = OptionChainResponse(**payload)
+        assert response.base_symbol == "SPY"
+        assert len(response.calls) == 1
+        assert len(response.puts) == 1
+
+        call = response.calls[0]
+        assert call.option_details is not None
+        assert call.option_details.strike_price == Decimal("500")
+        assert call.option_details.greeks.delta == Decimal("0.52")
+        assert call.previous_close == Decimal("159.00")
+        assert call.on_day_change == Decimal("1.50")
+
+        put = response.puts[0]
+        assert put.option_details is not None
+        assert put.option_details.mid_price == Decimal("0.02")
+
+    def test_chain_without_option_details(self) -> None:
+        """Chain entries without optionDetails still deserialize fine."""
+        payload = {
+            "baseSymbol": "SPY",
+            "calls": [
+                {
+                    "instrument": {"symbol": "SPY260409C00500000", "type": "OPTION"},
+                    "outcome": "SUCCESS",
+                    "bid": "158.59",
+                    "ask": "161.40",
+                }
+            ],
+            "puts": [],
+        }
+        response = OptionChainResponse(**payload)
+        assert response.calls[0].option_details is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #20 — the `/option-chain` endpoint returns `optionDetails` (with `strikePrice`, `midPrice`, and full `greeks`) inline for each call/put entry, but the `Quote` model lacked these fields so Pydantic silently dropped the data.

- **Extracted `GreekValues` into a new `greeks.py` module** to break the circular import between `quote.py` → `option.py` → `quote.py`. The re-export in `option.py` preserves backwards compatibility (`from public_api_sdk.models.option import GreekValues` still works).
- **Added `ChainOptionDetails` model** to `quote.py` with `strike_price`, `mid_price`, and optional `greeks` fields — distinct from the existing `OptionDetails` in `option.py` which models order/preflight metadata with different fields.
- **Added three new optional fields to `Quote`**: `option_details` (`ChainOptionDetails`), `previous_close` (`Decimal`), and `on_day_change` (`Decimal`). All use `AliasChoices` for camelCase/snake_case support, consistent with existing fields.
- **Exported `GreekValues` and `ChainOptionDetails`** from `models/__init__.py`.

### Why a separate module instead of `TYPE_CHECKING` + `model_rebuild()`?

Extracting `GreekValues` into `greeks.py` breaks the circular dependency structurally rather than working around it with deferred resolution hacks. `GreekValues` has no dependencies on anything in `option.py`, so it's a clean extraction. Both `quote.py` and `option.py` now import from `greeks.py` with no cycles.

## Test plan

- [x] Existing `TestQuoteDeserialization` tests pass (backward compat)
- [x] Existing `TestGreeksResponseDeserialization` tests pass (import path compat)
- [x] New: `test_option_details_absent` — Quote without option details still works
- [x] New: `test_option_details_with_greeks` — full chain payload with greeks, previousClose, onDayChange
- [x] New: `test_option_details_without_greeks` — optionDetails present but greeks absent
- [x] New: `TestOptionChainResponseDeserialization::test_full_chain_response` — realistic end-to-end chain payload through `OptionChainResponse`
- [x] New: `TestOptionChainResponseDeserialization::test_chain_without_option_details` — chain entries without optionDetails degrade gracefully
- [x] `GreekValues` still importable from `public_api_sdk.models.option` (backwards compat)
- [x] All 33 model deserialization tests pass (was 28 before this PR)