### PR TITLE
Honor Retry-After header in async client 429 retries

### DIFF
--- a/src/public_api_sdk/async_api_client.py
+++ b/src/public_api_sdk/async_api_client.py
@@ -139,7 +139,24 @@ class AsyncApiClient:
             )
             if should_retry_status:
                 retries += 1
-                await asyncio.sleep(self._backoff_factor * (2 ** (retries - 1)))
+                if response.status_code == 429:
+                    retry_after_header = response.headers.get("Retry-After")
+                    try:
+                        server_wait = (
+                            float(retry_after_header)
+                            if retry_after_header is not None
+                            else None
+                        )
+                    except (TypeError, ValueError):
+                        server_wait = None
+                else:
+                    server_wait = None
+                delay = (
+                    server_wait
+                    if server_wait is not None
+                    else self._backoff_factor * (2 ** (retries - 1))
+                )
+                await asyncio.sleep(delay)
                 continue
 
             return self._handle_response(response)

--- a/tests/test_async_api_client.py
+++ b/tests/test_async_api_client.py
@@ -378,6 +378,48 @@ class TestAsyncApiClientRetry:
         with pytest.raises(APIError):
             await self.client.get("/endpoint")
 
+    @pytest.mark.asyncio
+    async def test_429_retry_honors_retry_after_header(self) -> None:
+        """The server's Retry-After value must drive the sleep, not local backoff.
+
+        Public.com doubled rate limits to 10 req/s/account in Feb 2026; a 429
+        with Retry-After: 2 means the server wants 2 seconds of quiet. Ignoring
+        that header and sleeping 0.01s (backoff_factor) re-hits the limit
+        immediately and wastes the retry budget.
+        """
+        rate_limited = _make_httpx_response(
+            429,
+            data={"message": "slow down"},
+            headers={"Retry-After": "2"},
+        )
+        success = _make_httpx_response(200, data={"ok": True})
+        self.client._client.request = AsyncMock(side_effect=[rate_limited, success])
+
+        with patch("public_api_sdk.async_api_client.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            result = await self.client.get("/endpoint")
+
+        assert result == {"ok": True}
+        sleep_mock.assert_awaited_once()
+        slept = sleep_mock.await_args.args[0]
+        assert slept == 2, f"expected sleep=2 (server Retry-After), got {slept}"
+
+    @pytest.mark.asyncio
+    async def test_429_retry_falls_back_to_backoff_when_no_header(self) -> None:
+        """Without Retry-After, exponential backoff should drive the sleep."""
+        rate_limited = _make_httpx_response(
+            429, data={"message": "slow"}, headers={}
+        )
+        success = _make_httpx_response(200, data={"ok": True})
+        self.client._client.request = AsyncMock(side_effect=[rate_limited, success])
+
+        with patch("public_api_sdk.async_api_client.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            result = await self.client.get("/endpoint")
+
+        assert result == {"ok": True}
+        slept = sleep_mock.await_args.args[0]
+        # first retry: backoff_factor * 2^0 = 0.01
+        assert slept == pytest.approx(0.01)
+
 
 # ---------------------------------------------------------------------------
 # Close


### PR DESCRIPTION
The async _request_with_retry ignored the Retry-After header and used exponential local backoff instead. Under Public.com's 10 req/s limit (doubled Feb 2026) this re-hits the ceiling immediately on a burst and wastes the retry budget. Sync client already honored it via _retry_non_safe + RateLimitError.retry_after; async now matches.

Two new tests:
- header present -> sleep = header value
- header absent  -> sleep = exponential backoff

Full suite: 653 passed (+2 new).