### PR TITLE
fix Bar.volume type to Decimal for fractional API values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Public API Python SDK](banner.png)](https://public.com/api)
 
-![Version](https://img.shields.io/badge/version-0.1.14-brightgreen?style=flat-square)
+![Version](https://img.shields.io/badge/version-0.1.15-brightgreen?style=flat-square)
 ![Python](https://img.shields.io/badge/python-3.9%2B-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-Apache%202.0-green?style=flat-square)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "publicdotcom-py"
-version = "0.1.14"
+version = "0.1.15"
 description = "Python SDK for Public.com API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/public_api_sdk/__init__.py
+++ b/src/public_api_sdk/__init__.py
@@ -88,7 +88,7 @@ from .short_order import AsyncFlattenAndShortResult, FlattenAndShortResult
 from .strategy_preflight import StrategyPreflight
 from .subscription_manager import PriceSubscriptionManager
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"
 
 __all__ = [
     # Historic data

--- a/src/public_api_sdk/models/historic_data.py
+++ b/src/public_api_sdk/models/historic_data.py
@@ -41,7 +41,7 @@ class Bar(BaseModel):
     high: Decimal = Field(..., description="Highest price during the bar interval.")
     low: Decimal = Field(..., description="Lowest price during the bar interval.")
     value: Decimal = Field(..., description="Value of the bar.")
-    volume: int = Field(..., description="Volume traded during the bar interval.")
+    volume: Decimal = Field(..., description="Volume traded during the bar interval.")
     gain_amount: Optional[Decimal] = Field(
         None,
         validation_alias=AliasChoices("gain_amount", "gainAmount"),

--- a/tests/test_async_public_api_client.py
+++ b/tests/test_async_public_api_client.py
@@ -829,7 +829,7 @@ def _bars_payload(symbol: str = "AAPL", period: str = "YEAR") -> dict:
         "high": "187.00",
         "low": "184.50",
         "value": "186.50",
-        "volume": 50_000_000,
+        "volume": 6321507.562155,
     }
     session = {"expectedBars": 1, "bars": [bar]}
     return {
@@ -921,3 +921,4 @@ class TestGetBars:
         assert isinstance(bar, Bar)
         assert bar.open == Decimal("185.00")
         assert bar.close == Decimal("186.50")
+        assert bar.volume == Decimal("6321507.562155")

--- a/tests/test_public_api_client.py
+++ b/tests/test_public_api_client.py
@@ -900,7 +900,7 @@ def _bars_payload(symbol: str = "AAPL", period: str = "YEAR") -> dict:
         "high": "187.00",
         "low": "184.50",
         "value": "186.50",
-        "volume": 50_000_000,
+        "volume": 6321507.562155,
     }
     session = {"expectedBars": 1, "bars": [bar]}
     return {
@@ -981,6 +981,7 @@ class TestGetBars:
         assert isinstance(bar, Bar)
         assert bar.open == Decimal("185.00")
         assert bar.close == Decimal("186.50")
+        assert bar.volume == Decimal("6321507.562155")
 
     def test_parses_last_regular_trading_session_close(self) -> None:
         payload = _bars_payload()


### PR DESCRIPTION
The Public API returns fractional float values for bar volume (e.g. 6321507.562155), which raised ValidationError under the prior int typing. Bump version to 0.1.15.