### PR TITLE
ci: automated CI + release-to-PyPI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest
+
+  version-bump:
+    name: Version bump check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Ensure version was bumped above main
+        run: |
+          python -m pip install --upgrade pip packaging >/dev/null
+
+          PR_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          git fetch --quiet origin "$BASE_REF"
+          MAIN_VERSION=$(git show "origin/${BASE_REF}:pyproject.toml" \
+            | python -c "import sys, tomllib; print(tomllib.load(sys.stdin.buffer)['project']['version'])")
+
+          echo "PR version:   $PR_VERSION"
+          echo "Base version: $MAIN_VERSION"
+
+          python - "$PR_VERSION" "$MAIN_VERSION" <<'PY'
+          import sys
+          from packaging.version import Version
+
+          pr, base = Version(sys.argv[1]), Version(sys.argv[2])
+          if pr <= base:
+              print(
+                  f"::error::Version in pyproject.toml ({pr}) must be greater than "
+                  f"the base branch version ({base}). Please bump it."
+              )
+              sys.exit(1)
+          print(f"OK: {pr} > {base}")
+          PY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check for new version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.detect.outputs.version }}
+      should_release: ${{ steps.detect.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Detect release
+        id: detect
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists — nothing to release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New version v$VERSION — will release."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build distribution
+    needs: check
+    if: needs.check.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Check distribution
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [check, build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/publicdotcom-py
+    permissions:
+      id-token: write  # OIDC token for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub release
+    needs: [check, build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create tag + release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ needs.check.outputs.version }}"
+          gh release create "v$VERSION" dist/* \
+            --title "v$VERSION" \
+            --generate-notes \
+            --target "${{ github.sha }}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Public API Python SDK](banner.png)](https://public.com/api)
 
-![Version](https://img.shields.io/badge/version-0.1.16-brightgreen?style=flat-square)
+![Version](https://img.shields.io/badge/version-0.1.17-brightgreen?style=flat-square)
 ![Python](https://img.shields.io/badge/python-3.9%2B-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-Apache%202.0-green?style=flat-square)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Public API Python SDK](banner.png)](https://public.com/api)
 
-![Version](https://img.shields.io/badge/version-0.1.15-brightgreen?style=flat-square)
+![Version](https://img.shields.io/badge/version-0.1.16-brightgreen?style=flat-square)
 ![Python](https://img.shields.io/badge/python-3.9%2B-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-Apache%202.0-green?style=flat-square)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "publicdotcom-py"
-version = "0.1.15"
+version = "0.1.16"
 description = "Python SDK for Public.com API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "publicdotcom-py"
-version = "0.1.16"
+version = "0.1.17"
 description = "Python SDK for Public.com API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/public_api_sdk/__init__.py
+++ b/src/public_api_sdk/__init__.py
@@ -88,7 +88,7 @@ from .short_order import AsyncFlattenAndShortResult, FlattenAndShortResult
 from .strategy_preflight import StrategyPreflight
 from .subscription_manager import PriceSubscriptionManager
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"
 
 __all__ = [
     # Historic data

--- a/src/public_api_sdk/__init__.py
+++ b/src/public_api_sdk/__init__.py
@@ -88,7 +88,7 @@ from .short_order import AsyncFlattenAndShortResult, FlattenAndShortResult
 from .strategy_preflight import StrategyPreflight
 from .subscription_manager import PriceSubscriptionManager
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"
 
 __all__ = [
     # Historic data

--- a/src/public_api_sdk/models/historic_data.py
+++ b/src/public_api_sdk/models/historic_data.py
@@ -13,6 +13,8 @@ class BarPeriod(str, Enum):
     HALF_YEAR = "HALF_YEAR"
     YEAR = "YEAR"
     FIVE_YEARS = "FIVE_YEARS"
+    TEN_YEARS = "TEN_YEARS"
+    ALL = "ALL"
     YTD = "YTD"
     SINCE_PURCHASE = "SINCE_PURCHASE"
 

--- a/src/public_api_sdk/models/option.py
+++ b/src/public_api_sdk/models/option.py
@@ -304,6 +304,15 @@ class MultilegOrderRequest(MultilegValidationMixin, BaseModel):
     legs: List[OrderLegRequest] = Field(
         ..., description="From 2-6 legs. There can be at most 1 equity leg"
     )
+    use_margin: Optional[bool] = Field(
+        None,
+        validation_alias=AliasChoices("use_margin", "useMargin"),
+        serialization_alias="useMargin",
+        description=(
+            "Optional field to indicate whether to use margin buying power. "
+            "Defaults to True if not specified."
+        ),
+    )
 
     @field_validator("order_id")
     @classmethod

--- a/src/public_api_sdk/models/order.py
+++ b/src/public_api_sdk/models/order.py
@@ -534,6 +534,16 @@ class OrderRequest(OrderValidationMixin, BaseModel):
         serialization_alias="equityMarketSession",
         description="Specifies the equity market session for equity orders (e.g., CORE or EXTENDED).",
     )
+    use_margin: Optional[bool] = Field(
+        None,
+        validation_alias=AliasChoices("use_margin", "useMargin"),
+        serialization_alias="useMargin",
+        description=(
+            "If False, the order will be evaluated using cash-only buying power instead "
+            "of margin buying power when available. If True or omitted, margin will be "
+            "applied when allowed by the account configuration."
+        ),
+    )
 
     @field_serializer("order_side")
     def serialize_order_side(self, value: OrderSide) -> str:

--- a/tests/test_multileg_order_validation.py
+++ b/tests/test_multileg_order_validation.py
@@ -98,6 +98,48 @@ class TestMultilegOrderRequestValidation:
                 legs=self.base_legs,
             )
 
+    def test_use_margin_optional_and_omitted(self) -> None:
+        """use_margin defaults to None and is excluded from serialization when unset."""
+        order = MultilegOrderRequest(
+            order_id=self.valid_uuid,
+            quantity=10,
+            type=OrderType.LIMIT,
+            limit_price=Decimal("1.50"),
+            expiration=self.base_expiration,
+            legs=self.base_legs,
+        )
+        assert order.use_margin is None
+        assert "useMargin" not in order.model_dump(by_alias=True, exclude_none=True)
+
+    def test_use_margin_serializes_with_alias(self) -> None:
+        """use_margin serializes to the `useMargin` JSON key."""
+        order = MultilegOrderRequest(
+            order_id=self.valid_uuid,
+            quantity=10,
+            type=OrderType.LIMIT,
+            limit_price=Decimal("1.50"),
+            expiration=self.base_expiration,
+            legs=self.base_legs,
+            use_margin=False,
+        )
+        assert order.use_margin is False
+        assert order.model_dump(by_alias=True, exclude_none=True)["useMargin"] is False
+
+    def test_use_margin_accepts_camel_case_alias(self) -> None:
+        """use_margin is populatable from the `useMargin` alias."""
+        order = MultilegOrderRequest.model_validate(
+            {
+                "orderId": self.valid_uuid,
+                "quantity": 10,
+                "type": "LIMIT",
+                "limitPrice": "1.50",
+                "expiration": {"timeInForce": "DAY"},
+                "legs": [leg.model_dump(by_alias=True) for leg in self.base_legs],
+                "useMargin": True,
+            }
+        )
+        assert order.use_margin is True
+
 
 class TestSharedMultilegValidation:
     """Tests for validations shared between MultilegOrderRequest and PreflightMultiLegRequest."""

--- a/tests/test_order_preflight_validation.py
+++ b/tests/test_order_preflight_validation.py
@@ -56,6 +56,48 @@ class TestOrderRequestValidation:
                 quantity=100,
             )
 
+    def test_use_margin_optional_and_omitted(self) -> None:
+        """use_margin defaults to None and is excluded from serialization when unset."""
+        order = OrderRequest(
+            order_id=self.valid_uuid,
+            instrument=self.base_instrument,
+            order_side=OrderSide.BUY,
+            order_type=OrderType.MARKET,
+            expiration=self.base_expiration,
+            quantity=100,
+        )
+        assert order.use_margin is None
+        assert "useMargin" not in order.model_dump(by_alias=True, exclude_none=True)
+
+    def test_use_margin_serializes_with_alias(self) -> None:
+        """use_margin serializes to the `useMargin` JSON key."""
+        order = OrderRequest(
+            order_id=self.valid_uuid,
+            instrument=self.base_instrument,
+            order_side=OrderSide.BUY,
+            order_type=OrderType.MARKET,
+            expiration=self.base_expiration,
+            quantity=100,
+            use_margin=False,
+        )
+        assert order.use_margin is False
+        assert order.model_dump(by_alias=True, exclude_none=True)["useMargin"] is False
+
+    def test_use_margin_accepts_camel_case_alias(self) -> None:
+        """use_margin is populatable from the `useMargin` alias."""
+        order = OrderRequest.model_validate(
+            {
+                "orderId": self.valid_uuid,
+                "instrument": {"symbol": "AAPL", "type": "EQUITY"},
+                "orderSide": "BUY",
+                "orderType": "MARKET",
+                "expiration": {"timeInForce": "DAY"},
+                "quantity": "100",
+                "useMargin": True,
+            }
+        )
+        assert order.use_margin is True
+
 
 class TestSharedValidation:
     """Tests for validations shared between OrderRequest and PreflightRequest."""

--- a/tests/test_public_api_client.py
+++ b/tests/test_public_api_client.py
@@ -929,6 +929,18 @@ class TestGetBars:
         url = self.client.api_client.get.call_args[0][0]
         assert url == "/userapigateway/historicdata/EQUITY/AAPL/YEAR/ONE_HOUR"
 
+    def test_calls_url_with_ten_years_period(self) -> None:
+        self.client.api_client.get = Mock(return_value=_bars_payload(period="TEN_YEARS"))
+        self.client.get_bars("AAPL", BarPeriod.TEN_YEARS)
+        url = self.client.api_client.get.call_args[0][0]
+        assert url == "/userapigateway/historicdata/EQUITY/AAPL/TEN_YEARS"
+
+    def test_calls_url_with_all_period(self) -> None:
+        self.client.api_client.get = Mock(return_value=_bars_payload(period="ALL"))
+        self.client.get_bars("AAPL", BarPeriod.ALL)
+        url = self.client.api_client.get.call_args[0][0]
+        assert url == "/userapigateway/historicdata/EQUITY/AAPL/ALL"
+
     def test_calls_url_with_crypto_instrument_type(self) -> None:
         self.client.api_client.get = Mock(return_value=_bars_payload(symbol="BTC"))
         self.client.get_bars(


### PR DESCRIPTION
## What

Adds GitHub Actions automation for the release process.

- **`ci.yml`** — on PRs to `main`:
  - Runs the `pytest` matrix across Python 3.9–3.12.
  - Enforces that `pyproject.toml`'s `version` is bumped above the base branch (fails the PR otherwise).
- **`release.yml`** — on push to `main` (i.e. after merge):
  - Builds sdist + wheel, runs `twine check`.
  - Publishes to PyPI via **Trusted Publishing (OIDC)** using the `pypi` environment — no stored secrets.
  - Creates the `v{version}` git tag + a GitHub Release with auto-generated notes.
  - Skips automatically if the tag for the current version already exists.

Also bumps the version to **0.1.17** and brings `upstream/main` up to date with the pending `useMargin` commits.

## Testing this out

Merging this PR will trigger `release.yml` and publish **0.1.17** to PyPI as a live test of the pipeline.

## Follow-up (after merge)

Branch protection on `main` will be applied to require a PR + the `Test` and `Version bump check` status checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)