### PR TITLE
docs + feat: README overhaul, 24-hour sessions, overnight bars, and spec updates (0.1.18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,8 @@ print(f"Multi-leg order placed: {multileg_response.order_id}")
 
 Every placement method on the sync client (`place_order`, `place_multileg_order`, the spread helpers, `place_short_order`, and `cancel_and_replace_order`) returns a `NewOrder` — a live handle on the submitted order.
 
+All the wait helpers below tolerate the brief window right after placement where the API hasn't indexed the new order yet (`get_order` returns 404 for a second or two) — you can call them immediately after placing.
+
 ##### Waiting for a fill
 
 ```python

--- a/README.md
+++ b/README.md
@@ -1179,6 +1179,15 @@ client.price_stream.subscribe(
 # update polling frequency
 client.price_stream.set_polling_frequency(subscription_id, 5.0)
 
+# pause a subscription without cancelling it, then resume later
+client.price_stream.pause(subscription_id)
+client.price_stream.resume(subscription_id)
+
+# inspect a subscription's current settings
+info = client.price_stream.get_subscription_info(subscription_id)
+if info:
+    print(f"Polling every {info.polling_frequency}s")
+
 # get all active subscriptions
 active = client.price_stream.get_active_subscriptions()
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ instrument = client.get_instrument(
 
 print(f"Symbol: {instrument.instrument.symbol}")
 print(f"Type: {instrument.instrument.type}")
+print(f"Exchange: {instrument.exchange_name}")  # e.g. "NASDAQ"; None when not provided
 print(f"Trading: {instrument.trading}")
 print(f"Fractional Trading: {instrument.fractional_trading}")
 print(f"Option Trading: {instrument.option_trading}")
@@ -402,6 +403,30 @@ bars = client.get_bars("SPX", BarPeriod.YEAR, instrument_type=InstrumentType.IND
 ```
 
 Supported values: `EQUITY`, `CRYPTO`, `OPTION`, `INDEX`. Any other `InstrumentType` raises `ValueError`.
+
+##### Trading session toggle
+
+For DAY equity charts, `trading_session_toggle` controls which sessions are included:
+
+- `TradingSessionToggle.REGULAR_HOURS` — 9:30 AM - 4:00 PM ET only
+- `TradingSessionToggle.REGULAR_AND_EXTENDED_HOURS` — 4:00 AM - 8:00 PM ET (server default when omitted)
+- `TradingSessionToggle.ALL_SESSIONS` — midnight-to-midnight, adding the overnight ATS sessions
+
+```python
+from public_api_sdk import BarPeriod, TradingSessionToggle
+
+bars = client.get_bars(
+    "AAPL",
+    BarPeriod.DAY,
+    trading_session_toggle=TradingSessionToggle.ALL_SESSIONS,
+)
+
+# Overnight buckets are only populated with ALL_SESSIONS
+if bars.pre_market_overnight:
+    print(f"Overnight 00:00-04:00 bars: {len(bars.pre_market_overnight.bars)}")
+if bars.post_market_overnight:
+    print(f"Overnight 20:00-24:00 bars: {len(bars.post_market_overnight.bars)}")
+```
 
 ##### Last regular trading session close
 
@@ -496,6 +521,7 @@ When placing equity orders, you can optionally specify the market session using 
 
 - `EquityMarketSession.CORE` - Trade during regular market hours (9:30 AM - 4:00 PM ET)
 - `EquityMarketSession.EXTENDED` - Trade during pre-market (4:00 AM - 9:30 AM ET) and after-hours (4:00 PM - 8:00 PM ET)
+- `EquityMarketSession.TWENTY_FOUR_HOURS` - Trade around the clock, including the overnight sessions
 
 ```python
 from public_api_sdk import EquityMarketSession
@@ -505,6 +531,9 @@ equity_market_session=EquityMarketSession.CORE
 
 # For extended hours trading
 equity_market_session=EquityMarketSession.EXTENDED
+
+# For 24-hour trading
+equity_market_session=EquityMarketSession.TWENTY_FOUR_HOURS
 ```
 
 This parameter is optional and applies to both preflight calculations and order placement for equity instruments.
@@ -1695,7 +1724,7 @@ See `example_async_client.py` for a full async example that demonstrates:
 
 ## Error Handling
 
-All API errors inherit from `APIError` and carry a `status_code` and `response_data` for full context.
+All API errors inherit from `APIError` and carry a `status_code`, `response_data`, and — when the API provides one — a machine-readable `error_code` for full context.
 
 | Exception | HTTP status | Typical cause |
 |-----------|-------------|---------------|

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ pip install -e .
 $ pip install -e ".[dev]"  # for dev dependencies
 
 $ # run example
-$ python example.py
+$ python examples/example.py
 ```
 
 ### Run tests
@@ -83,6 +83,9 @@ from public_api_sdk import OrderInstrument, InstrumentType
 quotes = client.get_quotes([
     OrderInstrument(symbol="AAPL", type=InstrumentType.EQUITY)
 ])
+
+# Clean up when done (cancels subscriptions and releases resources)
+client.close()
 ```
 
 ## Async Quick Start
@@ -1626,6 +1629,8 @@ See `example_strategy_preflight.py` for a self-contained example that:
 - Resolves the nearest option expiration automatically
 - Runs all four spread types (CALL/PUT × credit/debit) back-to-back
 
+`example_async_strategy_preflight.py` is the async equivalent, running the same four spreads through the OSI-direct preflight helpers on `AsyncPublicApiClient`.
+
 ### Historic Bar Data Example
 
 See `example_historic_data.py` for a runnable example that demonstrates:
@@ -1643,6 +1648,13 @@ See `example_options.py` for a comprehensive options trading example that shows:
 - Performing multi-leg preflight calculations
 - Placing multi-leg option orders
 
+### Order Status Subscriptions
+
+See `example_order_subscription.py` for three ways to track an order after placement:
+- Callback-based status updates via `new_order.subscribe_updates()`
+- Synchronous waiting with `wait_for_status()` / `wait_for_fill()`
+- Async callbacks on order updates
+
 ### Price Subscription (Sync)
 
 See `example_price_subscription.py` for complete examples including:
@@ -1650,6 +1662,13 @@ See `example_price_subscription.py` for complete examples including:
 - Advanced async callbacks
 - Multiple concurrent subscriptions
 - Custom price alert system
+
+### Price-Triggered Order Bot
+
+See `example_price_triggered_order.py` for a small bot that combines price subscriptions with order placement:
+- Monitors a symbol via `client.price_stream` until a target price is reached
+- Places a limit order when the threshold triggers, then tracks it via `NewOrder`
+- Ships with a `DRY_RUN` guard (defaults to on) so it's safe to run as-is
 
 ### Async Client
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,13 @@ The `default_account_number` configuration option simplifies API calls by elimin
 
 ```python
 # With default_account_number configured
-from public_api_sdk import OrderInstrument, InstrumentType
+from public_api_sdk import (
+    PublicApiClient,
+    PublicApiClientConfiguration,
+    ApiKeyAuthConfig,
+    OrderInstrument,
+    InstrumentType,
+)
 
 config = PublicApiClientConfiguration(
     default_account_number="INSERT_ACCOUNT_NUMBER"
@@ -270,6 +276,7 @@ from public_api_sdk import (
     BondInstrumentDetails,
     CryptoInstrumentDetails,
     ShortingAvailability,
+    InstrumentType,
 )
 
 instrument = client.get_instrument(
@@ -323,7 +330,7 @@ instruments = client.get_all_instruments(
 
 #### Get Historic Bar Data
 
-Fetch OHLCV bar data for any symbol over a standard time period. The response is split into pre-market, regular-market, and after-hours sessions, each containing a list of `Bar` objects.
+Fetch OHLCV bar data for any symbol over a standard time period. The response is split into three sessions — `bars.pre_market`, `bars.regular_market`, and `bars.after_market` — each containing a list of `Bar` objects.
 
 ```python
 from public_api_sdk import BarPeriod
@@ -335,14 +342,14 @@ for bar in bars.regular_market.bars:
     print(f"  {bar.timestamp}  O={bar.open}  H={bar.high}  L={bar.low}  C={bar.close}  V={bar.volume}")
 ```
 
-Available periods: `DAY`, `WEEK`, `MONTH`, `QUARTER`, `HALF_YEAR`, `YEAR`, `FIVE_YEARS`, `YTD`, `SINCE_PURCHASE`.
+Available periods: `DAY`, `WEEK`, `MONTH`, `QUARTER`, `HALF_YEAR`, `YEAR`, `FIVE_YEARS`, `TEN_YEARS`, `ALL`, `YTD`, `SINCE_PURCHASE`.
 
 ##### Aggregation override
 
 Override the bar size by passing an `aggregation`:
 
 ```python
-from public_api_sdk import BarAggregation
+from public_api_sdk import BarAggregation, BarPeriod
 
 # Today's intraday bars at 5-minute resolution
 bars = client.get_bars("AAPL", BarPeriod.DAY, aggregation=BarAggregation.FIVE_MINUTES)
@@ -422,7 +429,7 @@ print(f"Available expirations: {expirations.expirations}")
 Retrieve the option chain for a specific expiration date.
 
 ```python
-from public_api_sdk import OptionChainRequest, InstrumentType
+from public_api_sdk import OptionChainRequest, OrderInstrument, InstrumentType
 
 option_chain = client.get_option_chain(
     OptionChainRequest(
@@ -556,6 +563,20 @@ hypothetical = client.perform_preflight_calculation(
 Calculate estimated costs for complex multi-leg option strategies.
 
 ```python
+from datetime import datetime, timezone
+from decimal import Decimal
+from public_api_sdk import (
+    PreflightMultiLegRequest,
+    OrderLegRequest,
+    LegInstrument,
+    LegInstrumentType,
+    OrderSide,
+    OrderType,
+    OpenCloseIndicator,
+    OrderExpirationRequest,
+    TimeInForce,
+)
+
 preflight_multi = PreflightMultiLegRequest(
     order_type=OrderType.LIMIT,
     expiration=OrderExpirationRequest(
@@ -806,7 +827,17 @@ See `examples/example_strategy_preflight.py` for a complete runnable example tha
 Submit a single-leg equity or option order.
 
 ```python
-from public_api_sdk import OrderRequest, OrderInstrument, InstrumentType, EquityMarketSession
+from public_api_sdk import (
+    OrderRequest,
+    OrderInstrument,
+    InstrumentType,
+    OrderSide,
+    OrderType,
+    OrderExpirationRequest,
+    TimeInForce,
+    EquityMarketSession,
+)
+from decimal import Decimal
 import uuid
 
 order_request = OrderRequest(
@@ -817,12 +848,15 @@ order_request = OrderRequest(
     expiration=OrderExpirationRequest(time_in_force=TimeInForce.DAY),
     quantity=10,
     limit_price=Decimal("227.50"),
-    equity_market_session=EquityMarketSession.EXTENDED  # Optional: CORE or EXTENDED
+    equity_market_session=EquityMarketSession.EXTENDED,  # Optional: CORE or EXTENDED
+    # use_margin=False,  # Optional: force cash-only buying power (see note below)
 )
 
 order_response = client.place_order(order_request)
 print(f"Order placed with ID: {order_response.order_id}")
 ```
+
+> **Margin vs. cash buying power.** `OrderRequest` accepts an optional `use_margin: bool`. When omitted (or `True`), the order is evaluated against margin buying power where the account allows it. Pass `use_margin=False` to force the order to be evaluated using **cash-only** buying power instead. The same flag is accepted on `MultilegOrderRequest`.
 
 ##### Place Short Order
 
@@ -872,7 +906,18 @@ Submit a multi-leg option strategy order.
 
 ```python
 from datetime import datetime, timezone
-from public_api_sdk import MultilegOrderRequest
+from decimal import Decimal
+from public_api_sdk import (
+    MultilegOrderRequest,
+    OrderLegRequest,
+    LegInstrument,
+    LegInstrumentType,
+    OrderSide,
+    OrderType,
+    OpenCloseIndicator,
+    OrderExpirationRequest,
+    TimeInForce,
+)
 import uuid
 
 multileg_order = MultilegOrderRequest(
@@ -941,7 +986,13 @@ Atomically cancel an existing open order and submit a replacement with updated p
 > **Note:** Cancel-and-replace currently supports **crypto (quantity-based) orders** and **options orders** only. Equity order support is coming soon.
 
 ```python
-from public_api_sdk import CancelAndReplaceRequest
+from public_api_sdk import (
+    CancelAndReplaceRequest,
+    OrderType,
+    OrderExpirationRequest,
+    TimeInForce,
+)
+from decimal import Decimal
 import uuid
 
 replacement = client.cancel_and_replace_order(
@@ -980,6 +1031,7 @@ print(f"Status: {details.status}")
 from public_api_sdk import (
     PublicApiClient,
     PublicApiClientConfiguration,
+    ApiKeyAuthConfig,
     OrderInstrument,
     InstrumentType,
     PriceChange,
@@ -1141,6 +1193,8 @@ print(f"Transactions: {len(history.transactions)}")
 ### Market Data
 
 ```python
+from public_api_sdk import OrderInstrument, InstrumentType
+
 # One-off quotes
 quotes = await client.get_quotes([
     OrderInstrument(symbol="MSFT", type=InstrumentType.EQUITY),
@@ -1266,7 +1320,13 @@ Atomically cancel an existing open order and submit a replacement.
 > **Note:** Cancel-and-replace currently supports **crypto (quantity-based) orders** and **options orders** only. Equity order support is coming soon.
 
 ```python
-from public_api_sdk import CancelAndReplaceRequest
+from public_api_sdk import (
+    CancelAndReplaceRequest,
+    OrderType,
+    OrderExpirationRequest,
+    TimeInForce,
+)
+from decimal import Decimal
 import uuid
 
 replacement = await client.cancel_and_replace_order(
@@ -1293,7 +1353,7 @@ The async client exposes `client.price_stream`, an `AsyncPriceStream` instance b
 #### Subscribe
 
 ```python
-from public_api_sdk import PriceChange, SubscriptionConfig
+from public_api_sdk import PriceChange, SubscriptionConfig, OrderInstrument, InstrumentType
 
 async def on_price_change(change: PriceChange) -> None:
     symbol = change.instrument.symbol
@@ -1366,7 +1426,15 @@ await client.price_stream.unsubscribe_all()
 ### Preflight Calculations (Async)
 
 ```python
-from public_api_sdk import PreflightRequest, OrderSide, OrderType, OrderExpirationRequest, TimeInForce
+from public_api_sdk import (
+    PreflightRequest,
+    OrderInstrument,
+    InstrumentType,
+    OrderSide,
+    OrderType,
+    OrderExpirationRequest,
+    TimeInForce,
+)
 from decimal import Decimal
 
 preflight = await client.perform_preflight_calculation(
@@ -1408,6 +1476,7 @@ print(f"Estimated credit: ${abs(cost):.2f}")
 ### Error Handling (Async)
 
 ```python
+from public_api_sdk import AsyncPublicApiClient
 from public_api_sdk.exceptions import (
     APIError,
     AuthenticationError,
@@ -1519,6 +1588,8 @@ All API errors inherit from `APIError` and carry a `status_code` and `response_d
 | `APIError` | any | Base class; catches all of the above |
 
 ```python
+from decimal import Decimal
+from public_api_sdk import OptionType
 from public_api_sdk.exceptions import (
     APIError,
     AuthenticationError,

--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@
 
 A Python SDK for interacting with the Public Trading API, providing a simple and intuitive interface for trading operations, market data retrieval, and account management.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Async Quick Start](#async-quick-start)
+- [API Reference](#api-reference)
+  - [Client Configuration](#client-configuration) — API key, token validity, default account
+  - [Account Management](#account-management) — accounts, portfolio, history
+  - [Market Data](#market-data) — quotes, instruments, historic bars
+  - [Options Trading](#options-trading) — expirations, chains, greeks
+  - [Order Management](#order-management) — preflight, spreads, placing & tracking orders
+  - [Price Subscription](#price-subscription)
+- [Async Client](#async-client)
+  - [Configuration](#configuration) & [Context Manager](#context-manager)
+  - [Market Data](#market-data-1) & [Order Placement and Tracking](#order-placement-and-tracking)
+  - [Async Price Subscriptions](#async-price-subscriptions)
+  - [Error Handling (Async)](#error-handling-async)
+- [Examples](#examples)
+- [Error Handling](#error-handling)
+- [Important Notes](#important-notes)
+
 ## Installation
 
 ### From PyPI
@@ -326,8 +347,6 @@ instruments = client.get_all_instruments(
 )
 ```
 
-### Options Trading
-
 #### Get Historic Bar Data
 
 Fetch OHLCV bar data for any symbol over a standard time period. The response is split into three sessions — `bars.pre_market`, `bars.regular_market`, and `bars.after_market` — each containing a list of `Bar` objects.
@@ -405,6 +424,8 @@ bars = client.get_bars(
 if bars.total_gain_loss is not None:
     print(f"Gain/loss since purchase: ${bars.total_gain_loss} ({bars.total_gain_loss_percentage}%)")
 ```
+
+### Options Trading
 
 #### Get Option Expirations
 
@@ -852,9 +873,11 @@ order_request = OrderRequest(
     # use_margin=False,  # Optional: force cash-only buying power (see note below)
 )
 
-order_response = client.place_order(order_request)
-print(f"Order placed with ID: {order_response.order_id}")
+new_order = client.place_order(order_request)  # returns a NewOrder
+print(f"Order placed with ID: {new_order.order_id}")
 ```
+
+`place_order` returns a `NewOrder` handle you can use to wait for fills, subscribe to status changes, or cancel — see [Tracking Orders with NewOrder](#tracking-orders-with-neworder) below.
 
 > **Margin vs. cash buying power.** `OrderRequest` accepts an optional `use_margin: bool`. When omitted (or `True`), the order is evaluated against margin buying power where the account allows it. Pass `use_margin=False` to force the order to be evaluated using **cash-only** buying power instead. The same flag is accepted on `MultilegOrderRequest`.
 
@@ -954,6 +977,74 @@ multileg_order = MultilegOrderRequest(
 multileg_response = client.place_multileg_order(multileg_order)
 print(f"Multi-leg order placed: {multileg_response.order_id}")
 ```
+
+#### Tracking Orders with NewOrder
+
+Every placement method on the sync client (`place_order`, `place_multileg_order`, the spread helpers, `place_short_order`, and `cancel_and_replace_order`) returns a `NewOrder` — a live handle on the submitted order.
+
+##### Waiting for a fill
+
+```python
+from public_api_sdk import WaitTimeoutError
+
+try:
+    # Poll until filled; raises WaitTimeoutError after 60 seconds
+    filled = new_order.wait_for_fill(timeout=60)
+    print(f"Filled at ${filled.average_price}")
+except WaitTimeoutError as e:
+    # e.current_order holds the last-seen order state (may be partially filled)
+    print("Order not filled within 60 seconds")
+    new_order.cancel()
+```
+
+Pass `on_partial_fill` to observe partial fills while waiting:
+
+```python
+def on_partial(order):
+    print(f"Partial fill: {order.filled_quantity} shares so far")
+
+filled = new_order.wait_for_fill(timeout=60, on_partial_fill=on_partial)
+```
+
+##### Waiting for any terminal status
+
+```python
+# FILLED, CANCELLED, REJECTED, EXPIRED, or REPLACED
+result = new_order.wait_for_terminal_status(timeout=120)
+print(f"Final status: {result.status}")
+```
+
+You can also wait for a specific status (or list of statuses) with `wait_for_status`:
+
+```python
+from public_api_sdk import OrderStatus
+
+order = new_order.wait_for_status(OrderStatus.FILLED, timeout=60, polling_interval=1.0)
+```
+
+##### Status update subscriptions
+
+```python
+def on_order_update(update):
+    print(f"{update.old_status} -> {update.new_status}")
+
+subscription_id = new_order.subscribe_updates(on_order_update)
+
+# ... later
+new_order.unsubscribe()
+```
+
+##### Checking status and cancelling
+
+```python
+status = new_order.get_status()     # just the OrderStatus
+details = new_order.get_details()   # full Order: fills, prices, timestamps
+
+new_order.cancel()                  # cancellation is asynchronous — confirm it:
+new_order.wait_for_status(OrderStatus.CANCELLED, timeout=10)
+```
+
+The async client's counterpart is [`AsyncNewOrder`](#order-placement-and-tracking), which exposes the same helpers as coroutines.
 
 #### Get Order Status
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Public API Python SDK](banner.png)](https://public.com/api)
 
-![Version](https://img.shields.io/badge/version-0.1.17-brightgreen?style=flat-square)
+![Version](https://img.shields.io/badge/version-0.1.18-brightgreen?style=flat-square)
 ![Python](https://img.shields.io/badge/python-3.9%2B-blue?style=flat-square)
 ![License](https://img.shields.io/badge/license-Apache%202.0-green?style=flat-square)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "publicdotcom-py"
-version = "0.1.17"
+version = "0.1.18"
 description = "Python SDK for Public.com API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/public_api_sdk/__init__.py
+++ b/src/public_api_sdk/__init__.py
@@ -10,6 +10,7 @@ from .models import (
     BarsResponse,
     LastSessionClose,
     MarketSessionBars,
+    TradingSessionToggle,
     BondInstrumentDetails,
     CancelAndReplaceRequest,
     CryptoInstrumentDetails,
@@ -98,6 +99,7 @@ __all__ = [
     "BarsResponse",
     "LastSessionClose",
     "MarketSessionBars",
+    "TradingSessionToggle",
     # Auth
     "AuthConfig",
     "AsyncAuthConfig",

--- a/src/public_api_sdk/__init__.py
+++ b/src/public_api_sdk/__init__.py
@@ -88,7 +88,7 @@ from .short_order import AsyncFlattenAndShortResult, FlattenAndShortResult
 from .strategy_preflight import StrategyPreflight
 from .subscription_manager import PriceSubscriptionManager
 
-__version__ = "0.1.17"
+__version__ = "0.1.18"
 
 __all__ = [
     # Historic data

--- a/src/public_api_sdk/async_public_api_client.py
+++ b/src/public_api_sdk/async_public_api_client.py
@@ -50,6 +50,7 @@ from .models import (
     Quote,
     QuoteRequest,
     TimeInForce,
+    TradingSessionToggle,
 )
 from .models.async_new_order import AsyncNewOrder
 from .short_order import (
@@ -381,6 +382,7 @@ class AsyncPublicApiClient:
         instrument_type: InstrumentType = InstrumentType.EQUITY,
         aggregation: Optional[BarAggregation] = None,
         purchase_date: Optional[str] = None,
+        trading_session_toggle: Optional[TradingSessionToggle] = None,
     ) -> BarsResponse:
         """Fetch OHLCV bar data for a symbol over a given time period.
 
@@ -393,6 +395,11 @@ class AsyncPublicApiClient:
                 chooses an appropriate aggregation for the period.
             purchase_date: Required when ``period`` is ``BarPeriod.SINCE_PURCHASE``.
                 Format: ``"YYYY-MM-DD"``.
+            trading_session_toggle: Which sessions to include on the DAY equity
+                chart. When omitted the server defaults to
+                ``REGULAR_AND_EXTENDED_HOURS``. ``ALL_SESSIONS`` adds the
+                overnight ATS sessions (``pre_market_overnight`` and
+                ``post_market_overnight`` on the response).
 
         Returns:
             BarsResponse with pre-market, regular-market, and after-hours bars.
@@ -409,8 +416,12 @@ class AsyncPublicApiClient:
         )
         if aggregation is not None:
             path += f"/{aggregation.value}"
-        params = {"purchaseDate": purchase_date} if purchase_date else None
-        response = await self.api_client.get(path, params=params)
+        params = {}
+        if purchase_date:
+            params["purchaseDate"] = purchase_date
+        if trading_session_toggle is not None:
+            params["tradingSessionToggle"] = trading_session_toggle.value
+        response = await self.api_client.get(path, params=params or None)
         return BarsResponse(**response)
 
     async def get_option_greeks(

--- a/src/public_api_sdk/exceptions.py
+++ b/src/public_api_sdk/exceptions.py
@@ -14,6 +14,8 @@ class APIError(Exception):
             non-HTTP errors (e.g. network timeouts).
         response_data: Raw response body parsed as a dict, useful for
             extracting additional error detail provided by the API.
+        error_code: Machine-readable error code from the API response body
+            (the ``errorCode`` field), or ``None`` when absent.
     """
 
     def __init__(
@@ -26,6 +28,7 @@ class APIError(Exception):
         self.message = message
         self.status_code = status_code
         self.response_data = response_data or {}
+        self.error_code: Optional[str] = self.response_data.get("errorCode")
 
     def __str__(self) -> str:
         if self.status_code:

--- a/src/public_api_sdk/models/__init__.py
+++ b/src/public_api_sdk/models/__init__.py
@@ -6,6 +6,7 @@ from .historic_data import (
     BarsResponse,
     LastSessionClose,
     MarketSessionBars,
+    TradingSessionToggle,
 )
 from .account import Account, AccountType, AccountsResponse
 from .history import HistoryRequest, HistoryResponsePage
@@ -98,6 +99,7 @@ __all__ = [
     "BarsResponse",
     "LastSessionClose",
     "MarketSessionBars",
+    "TradingSessionToggle",
     "AccessTokenResponse",
     "Account",
     "AccountType",

--- a/src/public_api_sdk/models/async_new_order.py
+++ b/src/public_api_sdk/models/async_new_order.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 from .new_order import OrderSubscriptionConfig, OrderUpdateCallback, WaitTimeoutError
 from .order import Order, OrderStatus
+from ..exceptions import NotFoundError
 
 if TYPE_CHECKING:
     from ..async_order_subscription_manager import AsyncOrderSubscriptionManager
@@ -164,17 +165,24 @@ class AsyncNewOrder:
         )
 
         start = time.monotonic()
+        order: Optional[Order] = None
 
         while True:
-            order = await self.get_details()
-
-            if order.status in target_statuses:
-                return order
+            try:
+                order = await self.get_details()
+            except NotFoundError:
+                # freshly placed orders briefly return 404 until the backend
+                # indexes them — treat as pending and keep polling
+                pass
+            else:
+                if order.status in target_statuses:
+                    return order
 
             if timeout is not None and time.monotonic() - start >= timeout:
+                current = order.status if order else "not indexed yet"
                 raise WaitTimeoutError(
                     f"Timeout waiting for order {self._order_id} to reach "
-                    f"status {target_statuses}. Current status: {order.status}"
+                    f"status {target_statuses}. Current status: {current}"
                 )
 
             await asyncio.sleep(polling_interval)
@@ -218,22 +226,29 @@ class AsyncNewOrder:
         last_seen_order: Optional[Order] = None
 
         while True:
-            order = await self.get_details()
-            last_seen_order = order
+            try:
+                order = await self.get_details()
+            except NotFoundError:
+                # freshly placed orders briefly return 404 until the backend
+                # indexes them — treat as pending and keep polling
+                order = None
+            if order is not None:
+                last_seen_order = order
 
-            if order.status == OrderStatus.FILLED:
-                return order
+                if order.status == OrderStatus.FILLED:
+                    return order
 
-            if order.status == OrderStatus.PARTIALLY_FILLED and on_partial_fill:
-                if asyncio.iscoroutinefunction(on_partial_fill):
-                    await on_partial_fill(order)
-                else:
-                    on_partial_fill(order)
+                if order.status == OrderStatus.PARTIALLY_FILLED and on_partial_fill:
+                    if asyncio.iscoroutinefunction(on_partial_fill):
+                        await on_partial_fill(order)
+                    else:
+                        on_partial_fill(order)
 
             if timeout is not None and time.monotonic() - start >= timeout:
+                current = order.status if order else "not indexed yet"
                 raise WaitTimeoutError(
                     f"Order {self._order_id} did not fill within {timeout}s. "
-                    f"Current status: {order.status}",
+                    f"Current status: {current}",
                     current_order=last_seen_order,
                 )
 

--- a/src/public_api_sdk/models/historic_data.py
+++ b/src/public_api_sdk/models/historic_data.py
@@ -19,6 +19,20 @@ class BarPeriod(str, Enum):
     SINCE_PURCHASE = "SINCE_PURCHASE"
 
 
+class TradingSessionToggle(str, Enum):
+    """Which sessions to include on the DAY equity chart.
+
+    REGULAR_HOURS: 09:30-16:00 ET only.
+    REGULAR_AND_EXTENDED_HOURS: 04:00-20:00 ET (server default when omitted).
+    ALL_SESSIONS: midnight-to-midnight axis, adds the overnight ATS sessions
+        (pre_market_overnight 00:00-04:00 and post_market_overnight 20:00-24:00).
+    """
+
+    REGULAR_HOURS = "REGULAR_HOURS"
+    REGULAR_AND_EXTENDED_HOURS = "REGULAR_AND_EXTENDED_HOURS"
+    ALL_SESSIONS = "ALL_SESSIONS"
+
+
 class BarAggregation(str, Enum):
     ONE_MINUTE = "ONE_MINUTE"
     FIVE_MINUTES = "FIVE_MINUTES"
@@ -136,6 +150,24 @@ class BarsResponse(BaseModel):
         validation_alias=AliasChoices("after_market", "afterMarket"),
         serialization_alias="afterMarket",
         description="After-hours session bars.",
+    )
+    pre_market_overnight: Optional[MarketSessionBars] = Field(
+        None,
+        validation_alias=AliasChoices("pre_market_overnight", "preMarketOvernight"),
+        serialization_alias="preMarketOvernight",
+        description=(
+            "Overnight ATS bars 00:00-04:00 ET. Only present when the request"
+            " uses TradingSessionToggle.ALL_SESSIONS."
+        ),
+    )
+    post_market_overnight: Optional[MarketSessionBars] = Field(
+        None,
+        validation_alias=AliasChoices("post_market_overnight", "postMarketOvernight"),
+        serialization_alias="postMarketOvernight",
+        description=(
+            "Overnight ATS bars 20:00-24:00 ET. Only present when the request"
+            " uses TradingSessionToggle.ALL_SESSIONS."
+        ),
     )
     last_regular_trading_session_close: Optional[LastSessionClose] = Field(
         None,

--- a/src/public_api_sdk/models/instrument.py
+++ b/src/public_api_sdk/models/instrument.py
@@ -167,6 +167,12 @@ class Instrument(BaseModel):
         serialization_alias="optionContractPriceIncrements",
         description="Price increments for option contracts on this instrument.",
     )
+    exchange_name: Optional[str] = Field(
+        None,
+        validation_alias=AliasChoices("exchange_name", "exchangeName"),
+        serialization_alias="exchangeName",
+        description="The name of the exchange where the instrument is traded.",
+    )
 
 
 class InstrumentsRequest(BaseModel):

--- a/src/public_api_sdk/models/new_order.py
+++ b/src/public_api_sdk/models/new_order.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from pydantic import BaseModel, Field
 
 from .order import Order, OrderStatus
+from ..exceptions import NotFoundError
 
 if TYPE_CHECKING:
     from ..public_api_client import PublicApiClient
@@ -221,20 +222,27 @@ class NewOrder:
             target_statuses = target_status
 
         start_time = time.time()
+        order: Optional[Order] = None
 
         while True:
-            order = self.get_details()
-
-            if order.status in target_statuses:
-                return order
+            try:
+                order = self.get_details()
+            except NotFoundError:
+                # freshly placed orders briefly return 404 until the backend
+                # indexes them — treat as pending and keep polling
+                pass
+            else:
+                if order.status in target_statuses:
+                    return order
 
             # check timeout
             if timeout is not None:
                 elapsed = time.time() - start_time
                 if elapsed >= timeout:
+                    current = order.status if order else "not indexed yet"
                     raise WaitTimeoutError(
                         f"Timeout waiting for order {self._order_id} to reach "
-                        f"status {target_statuses}. Current status: {order.status}"
+                        f"status {target_statuses}. Current status: {current}"
                     )
 
             # sleep before next check
@@ -281,21 +289,28 @@ class NewOrder:
         last_seen_order: Optional["Order"] = None
 
         while True:
-            order = self.get_details()
-            last_seen_order = order
+            try:
+                order = self.get_details()
+            except NotFoundError:
+                # freshly placed orders briefly return 404 until the backend
+                # indexes them — treat as pending and keep polling
+                order = None
+            if order is not None:
+                last_seen_order = order
 
-            if order.status == OrderStatus.FILLED:
-                return order
+                if order.status == OrderStatus.FILLED:
+                    return order
 
-            if order.status == OrderStatus.PARTIALLY_FILLED and on_partial_fill:
-                on_partial_fill(order)
+                if order.status == OrderStatus.PARTIALLY_FILLED and on_partial_fill:
+                    on_partial_fill(order)
 
             if timeout is not None:
                 elapsed = time.time() - start_time
                 if elapsed >= timeout:
+                    current = order.status if order else "not indexed yet"
                     raise WaitTimeoutError(
                         f"Order {self._order_id} did not fill within {timeout}s. "
-                        f"Current status: {order.status}",
+                        f"Current status: {current}",
                         current_order=last_seen_order,
                     )
 

--- a/src/public_api_sdk/models/order.py
+++ b/src/public_api_sdk/models/order.py
@@ -114,6 +114,7 @@ class OpenCloseIndicator(str, Enum):
 class EquityMarketSession(str, Enum):
     CORE = "CORE"
     EXTENDED = "EXTENDED"
+    TWENTY_FOUR_HOURS = "TWENTY_FOUR_HOURS"
 
 class OrderExpiration(BaseModel):
     time_in_force: TimeInForce = Field(..., alias="timeInForce")

--- a/src/public_api_sdk/public_api_client.py
+++ b/src/public_api_sdk/public_api_client.py
@@ -39,6 +39,7 @@ from .models import (
     Quote,
     QuoteRequest,
     TimeInForce,
+    TradingSessionToggle,
 )
 from .order_subscription_manager import OrderSubscriptionManager
 from .price_stream import PriceStream
@@ -317,6 +318,7 @@ class PublicApiClient:
         instrument_type: InstrumentType = InstrumentType.EQUITY,
         aggregation: Optional[BarAggregation] = None,
         purchase_date: Optional[str] = None,
+        trading_session_toggle: Optional[TradingSessionToggle] = None,
     ) -> BarsResponse:
         """Fetch OHLCV bar data for a symbol over a given time period.
 
@@ -329,6 +331,11 @@ class PublicApiClient:
                 chooses an appropriate aggregation for the period.
             purchase_date: Required when ``period`` is ``BarPeriod.SINCE_PURCHASE``.
                 Format: ``"YYYY-MM-DD"``.
+            trading_session_toggle: Which sessions to include on the DAY equity
+                chart. When omitted the server defaults to
+                ``REGULAR_AND_EXTENDED_HOURS``. ``ALL_SESSIONS`` adds the
+                overnight ATS sessions (``pre_market_overnight`` and
+                ``post_market_overnight`` on the response).
 
         Returns:
             BarsResponse with pre-market, regular-market, and after-hours bars.
@@ -345,8 +352,12 @@ class PublicApiClient:
         )
         if aggregation is not None:
             path += f"/{aggregation.value}"
-        params = {"purchaseDate": purchase_date} if purchase_date else None
-        response = self.api_client.get(path, params=params)
+        params = {}
+        if purchase_date:
+            params["purchaseDate"] = purchase_date
+        if trading_session_toggle is not None:
+            params["tradingSessionToggle"] = trading_session_toggle.value
+        response = self.api_client.get(path, params=params or None)
         return BarsResponse(**response)
 
     def get_option_greeks(

--- a/tests/test_async_new_order.py
+++ b/tests/test_async_new_order.py
@@ -15,6 +15,7 @@ from public_api_sdk.models.order import (
     OrderType,
 )
 from public_api_sdk.models.instrument_type import InstrumentType
+from public_api_sdk.exceptions import NotFoundError
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +247,42 @@ class TestAsyncNewOrderWaitForFill:
         mock_client.get_order.return_value = _make_order(OrderStatus.NEW)
         with pytest.raises(WaitTimeoutError):
             await new_order.wait_for_fill(timeout=0.05)
+
+    @pytest.mark.asyncio
+    async def test_wait_for_fill_tolerates_not_yet_indexed_404(self) -> None:
+        """Freshly placed orders 404 briefly; wait_for_fill must keep polling."""
+        new_order, mock_client, _ = _make_async_new_order()
+        mock_client.get_order.side_effect = [
+            NotFoundError("Unknown error", 404, {}),
+            NotFoundError("Unknown error", 404, {}),
+            _make_order(OrderStatus.FILLED),
+        ]
+        result = await new_order.wait_for_fill(timeout=5, polling_interval=0.01)
+        assert result.status == OrderStatus.FILLED
+        assert mock_client.get_order.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_wait_for_status_tolerates_not_yet_indexed_404(self) -> None:
+        """wait_for_status must also survive the post-placement 404 window."""
+        new_order, mock_client, _ = _make_async_new_order()
+        mock_client.get_order.side_effect = [
+            NotFoundError("Unknown error", 404, {}),
+            _make_order(OrderStatus.FILLED),
+        ]
+        result = await new_order.wait_for_status(
+            OrderStatus.FILLED, timeout=5, polling_interval=0.01
+        )
+        assert result.status == OrderStatus.FILLED
+
+    @pytest.mark.asyncio
+    async def test_wait_for_fill_times_out_if_never_indexed(self) -> None:
+        """Persistent 404s end in WaitTimeoutError, not NotFoundError."""
+        new_order, mock_client, _ = _make_async_new_order()
+        mock_client.get_order.side_effect = NotFoundError("Unknown error", 404, {})
+        with pytest.raises(WaitTimeoutError) as exc_info:
+            await new_order.wait_for_fill(timeout=0.05, polling_interval=0.01)
+        assert "not indexed yet" in str(exc_info.value)
+        assert exc_info.value.current_order is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_async_public_api_client.py
+++ b/tests/test_async_public_api_client.py
@@ -21,7 +21,13 @@ from public_api_sdk import (
 )
 from public_api_sdk.models.account import AccountsResponse
 from public_api_sdk.models.async_new_order import AsyncNewOrder
-from public_api_sdk.models.historic_data import Bar, BarAggregation, BarPeriod, BarsResponse
+from public_api_sdk.models.historic_data import (
+    Bar,
+    BarAggregation,
+    BarPeriod,
+    BarsResponse,
+    TradingSessionToggle,
+)
 from public_api_sdk.models.history import HistoryRequest, HistoryResponsePage
 from public_api_sdk.models.instrument import Instrument
 from public_api_sdk.models.option import GreeksResponse
@@ -902,6 +908,33 @@ class TestGetBars:
         await self.client.get_bars("AAPL", BarPeriod.YEAR)
         params = self.client.api_client.get.call_args[1]["params"]
         assert params is None
+
+    @pytest.mark.asyncio
+    async def test_passes_trading_session_toggle_as_query_param(self) -> None:
+        self.client.api_client.get = AsyncMock(return_value=_bars_payload(period="DAY"))
+        await self.client.get_bars(
+            "AAPL",
+            BarPeriod.DAY,
+            trading_session_toggle=TradingSessionToggle.ALL_SESSIONS,
+        )
+        params = self.client.api_client.get.call_args[1]["params"]
+        assert params == {"tradingSessionToggle": "ALL_SESSIONS"}
+
+    @pytest.mark.asyncio
+    async def test_parses_overnight_sessions(self) -> None:
+        payload = _bars_payload(period="DAY")
+        payload["preMarketOvernight"] = {"expectedBars": 1, "bars": []}
+        payload["postMarketOvernight"] = {"expectedBars": 2, "bars": []}
+        self.client.api_client.get = AsyncMock(return_value=payload)
+        result = await self.client.get_bars(
+            "AAPL",
+            BarPeriod.DAY,
+            trading_session_toggle=TradingSessionToggle.ALL_SESSIONS,
+        )
+        assert result.pre_market_overnight is not None
+        assert result.pre_market_overnight.expected_bars == 1
+        assert result.post_market_overnight is not None
+        assert result.post_market_overnight.expected_bars == 2
 
     @pytest.mark.asyncio
     async def test_returns_bars_response(self) -> None:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -33,6 +33,28 @@ class TestAPIError:
         err = APIError("err")
         assert err.response_data == {}
 
+    def test_error_code_extracted_from_response_data(self) -> None:
+        err = APIError(
+            "err",
+            status_code=400,
+            response_data={"errorCode": "INSUFFICIENT_FUNDS", "message": "err"},
+        )
+        assert err.error_code == "INSUFFICIENT_FUNDS"
+
+    def test_error_code_none_when_absent(self) -> None:
+        err = APIError("err", status_code=400, response_data={"message": "err"})
+        assert err.error_code is None
+
+    def test_error_code_none_without_response_data(self) -> None:
+        err = APIError("err")
+        assert err.error_code is None
+
+    def test_error_code_on_subclasses(self) -> None:
+        err = ValidationError(
+            "bad", status_code=400, response_data={"errorCode": "INVALID_SYMBOL"}
+        )
+        assert err.error_code == "INVALID_SYMBOL"
+
     def test_status_code_none_by_default(self) -> None:
         err = APIError("err")
         assert err.status_code is None

--- a/tests/test_new_order.py
+++ b/tests/test_new_order.py
@@ -18,6 +18,7 @@ from public_api_sdk.models.order import (
     OrderType,
 )
 from public_api_sdk.models.instrument_type import InstrumentType
+from public_api_sdk.exceptions import NotFoundError
 
 
 class TestNewOrder:
@@ -214,6 +215,62 @@ class TestNewOrder:
 
         assert result == rejected_order
         assert result.status == OrderStatus.REJECTED
+
+    def test_wait_for_fill_tolerates_not_yet_indexed_404(self) -> None:
+        """Freshly placed orders 404 briefly; wait_for_fill must keep polling."""
+        filled_order = Order(
+            order_id=self.order_id,
+            instrument=OrderInstrument(symbol="AAPL", type=InstrumentType.EQUITY),
+            type=OrderType.LIMIT,
+            side=OrderSide.BUY,
+            status=OrderStatus.FILLED,
+            quantity=Decimal("10"),
+            filled_quantity=Decimal("10"),
+            average_price=Decimal("149.95"),
+        )
+        self.mock_client.get_order.side_effect = [
+            NotFoundError("Unknown error", 404, {}),
+            NotFoundError("Unknown error", 404, {}),
+            filled_order,
+        ]
+
+        result = self.new_order.wait_for_fill(timeout=5, polling_interval=0.01)
+
+        assert result == filled_order
+        assert self.mock_client.get_order.call_count == 3
+
+    def test_wait_for_status_tolerates_not_yet_indexed_404(self) -> None:
+        """wait_for_status must also survive the post-placement 404 window."""
+        filled_order = Order(
+            order_id=self.order_id,
+            instrument=OrderInstrument(symbol="AAPL", type=InstrumentType.EQUITY),
+            type=OrderType.LIMIT,
+            side=OrderSide.BUY,
+            status=OrderStatus.FILLED,
+            quantity=Decimal("10"),
+        )
+        self.mock_client.get_order.side_effect = [
+            NotFoundError("Unknown error", 404, {}),
+            filled_order,
+        ]
+
+        result = self.new_order.wait_for_status(
+            OrderStatus.FILLED, timeout=5, polling_interval=0.01
+        )
+
+        assert result == filled_order
+
+    def test_wait_for_fill_times_out_if_never_indexed(self) -> None:
+        """Persistent 404s end in WaitTimeoutError, not NotFoundError."""
+        self.mock_client.get_order.side_effect = NotFoundError(
+            "Unknown error", 404, {}
+        )
+
+        with pytest.raises(WaitTimeoutError) as exc_info:
+            self.new_order.wait_for_fill(timeout=0.05, polling_interval=0.01)
+
+        assert "not indexed yet" in str(exc_info.value)
+        assert exc_info.value.current_order is None
 
     def test_cancel(self) -> None:
         """Test cancelling an order."""

--- a/tests/test_order_preflight_validation.py
+++ b/tests/test_order_preflight_validation.py
@@ -7,6 +7,7 @@ import pytest
 
 from public_api_sdk.models.order import (
     CancelAndReplaceRequest,
+    EquityMarketSession,
     OpenCloseIndicator,
     OrderRequest,
     PreflightRequest,
@@ -97,6 +98,33 @@ class TestOrderRequestValidation:
             }
         )
         assert order.use_margin is True
+
+    def test_twenty_four_hours_market_session_on_order(self) -> None:
+        """TWENTY_FOUR_HOURS is a valid equity market session on orders."""
+        order = OrderRequest(
+            order_id=self.valid_uuid,
+            instrument=self.base_instrument,
+            order_side=OrderSide.BUY,
+            order_type=OrderType.MARKET,
+            expiration=self.base_expiration,
+            quantity=100,
+            equity_market_session=EquityMarketSession.TWENTY_FOUR_HOURS,
+        )
+        dump = order.model_dump(by_alias=True, exclude_none=True)
+        assert dump["equityMarketSession"] == "TWENTY_FOUR_HOURS"
+
+    def test_twenty_four_hours_market_session_on_preflight(self) -> None:
+        """TWENTY_FOUR_HOURS is a valid equity market session on preflight."""
+        preflight = PreflightRequest(
+            instrument=self.base_instrument,
+            order_side=OrderSide.BUY,
+            order_type=OrderType.MARKET,
+            expiration=self.base_expiration,
+            quantity=100,
+            equity_market_session=EquityMarketSession.TWENTY_FOUR_HOURS,
+        )
+        dump = preflight.model_dump(by_alias=True, exclude_none=True)
+        assert dump["equityMarketSession"] == "TWENTY_FOUR_HOURS"
 
 
 class TestSharedValidation:

--- a/tests/test_public_api_client.py
+++ b/tests/test_public_api_client.py
@@ -27,6 +27,7 @@ from public_api_sdk.models.historic_data import (
     BarPeriod,
     BarsResponse,
     LastSessionClose,
+    TradingSessionToggle,
 )
 from public_api_sdk.models.history import HistoryRequest, HistoryResponsePage
 from public_api_sdk.models.instrument import Instrument
@@ -337,6 +338,17 @@ class TestGetInstrument:
         result = self.client.get_instrument("AAPL", InstrumentType.EQUITY)
         assert isinstance(result, Instrument)
         assert result.instrument.symbol == "AAPL"
+
+    def test_parses_exchange_name(self) -> None:
+        payload = {**_INSTRUMENT_PAYLOAD, "exchangeName": "NASDAQ"}
+        self.client.api_client.get = Mock(return_value=payload)
+        result = self.client.get_instrument("AAPL", InstrumentType.EQUITY)
+        assert result.exchange_name == "NASDAQ"
+
+    def test_exchange_name_none_when_absent(self) -> None:
+        self.client.api_client.get = Mock(return_value=_INSTRUMENT_PAYLOAD)
+        result = self.client.get_instrument("AAPL", InstrumentType.EQUITY)
+        assert result.exchange_name is None
 
 
 class TestGetAllInstruments:
@@ -1029,6 +1041,53 @@ class TestGetBars:
         self.client.api_client.get = Mock(return_value=_bars_payload())
         result = self.client.get_bars("AAPL", BarPeriod.YEAR)
         assert result.last_regular_trading_session_close is None
+
+    def test_passes_trading_session_toggle_as_query_param(self) -> None:
+        self.client.api_client.get = Mock(return_value=_bars_payload(period="DAY"))
+        self.client.get_bars(
+            "AAPL",
+            BarPeriod.DAY,
+            trading_session_toggle=TradingSessionToggle.ALL_SESSIONS,
+        )
+        params = self.client.api_client.get.call_args[1]["params"]
+        assert params == {"tradingSessionToggle": "ALL_SESSIONS"}
+
+    def test_combines_purchase_date_and_trading_session_toggle(self) -> None:
+        self.client.api_client.get = Mock(
+            return_value=_bars_payload(period="SINCE_PURCHASE")
+        )
+        self.client.get_bars(
+            "AAPL",
+            BarPeriod.SINCE_PURCHASE,
+            purchase_date="2024-03-15",
+            trading_session_toggle=TradingSessionToggle.REGULAR_HOURS,
+        )
+        params = self.client.api_client.get.call_args[1]["params"]
+        assert params == {
+            "purchaseDate": "2024-03-15",
+            "tradingSessionToggle": "REGULAR_HOURS",
+        }
+
+    def test_parses_overnight_sessions(self) -> None:
+        payload = _bars_payload(period="DAY")
+        payload["preMarketOvernight"] = {"expectedBars": 1, "bars": []}
+        payload["postMarketOvernight"] = {"expectedBars": 2, "bars": []}
+        self.client.api_client.get = Mock(return_value=payload)
+        result = self.client.get_bars(
+            "AAPL",
+            BarPeriod.DAY,
+            trading_session_toggle=TradingSessionToggle.ALL_SESSIONS,
+        )
+        assert result.pre_market_overnight is not None
+        assert result.pre_market_overnight.expected_bars == 1
+        assert result.post_market_overnight is not None
+        assert result.post_market_overnight.expected_bars == 2
+
+    def test_overnight_sessions_none_when_absent(self) -> None:
+        self.client.api_client.get = Mock(return_value=_bars_payload())
+        result = self.client.get_bars("AAPL", BarPeriod.YEAR)
+        assert result.pre_market_overnight is None
+        assert result.post_market_overnight is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Combined release: README accuracy/discoverability overhaul **plus** SDK support for the latest API spec additions. Merging publishes `0.1.18` to PyPI with everything below.

## New features (spec sync)

- **`EquityMarketSession.TWENTY_FOUR_HOURS`** — around-the-clock equity orders (order placement + single-leg preflight)
- **`trading_session_toggle` on `get_bars`** (sync + async) with new `TradingSessionToggle` enum (`REGULAR_HOURS` / `REGULAR_AND_EXTENDED_HOURS` / `ALL_SESSIONS`)
- **Overnight bar buckets** — `pre_market_overnight` (00:00–04:00 ET) and `post_market_overnight` (20:00–24:00 ET) on `BarsResponse`, populated with `ALL_SESSIONS`
- **`exchange_name`** on the `Instrument` response model
- **`error_code`** — machine-readable code surfaced as a first-class attribute on `APIError` and all subclasses

Intentionally skipped: `lastTradingSessionClose` and `regularSessionClosingData` (marked `deprecated: true` in the spec).

## Bug fix (found via live testing)

- **`wait_for_fill` / `wait_for_status` no longer crash right after placement.** Freshly placed orders 404 on `get_order` for a couple of seconds until the backend indexes them; the wait helpers (sync `NewOrder` and `AsyncNewOrder`) previously raised `NotFoundError` on the first poll. They now treat the 404 window as "pending" and keep polling; persistent 404s still end in `WaitTimeoutError` at the deadline.

## Documentation fixes

### Factual
- Add missing `TEN_YEARS` and `ALL` to the `BarPeriod` list
- Document the `use_margin` flag on `OrderRequest` / `MultilegOrderRequest`
- Correct bar-session naming to the actual `pre_market` / `regular_market` / `after_market` attributes

### Copy-paste-safe snippets
- Complete missing imports across ~15 code blocks so each is runnable standalone; every imported name verified against the package's public exports at runtime

### Discoverability
- Add a table of contents (all anchors verified)
- Document the sync `NewOrder` handle (`wait_for_fill`, `wait_for_status`, `subscribe_updates`, `get_status`/`get_details`, `cancel`)
- Move "Get Historic Bar Data" out of Options Trading into Market Data
- Document sync `PriceStream.pause()` / `resume()` / `get_subscription_info()`
- Fix `python example.py` → `python examples/example.py`; show `client.close()` in Quick Start
- Reference the previously unmentioned `example_order_subscription.py`, `example_price_triggered_order.py`, and `example_async_strategy_preflight.py`

### Deliberately excluded
- `example_manual.py` remains unreferenced — it's a dev scratchpad

## Testing

- 836 tests pass (20 new: session-toggle wiring, overnight parsing, 24-hour session serialization, `exchange_name`, `error_code`, post-placement 404 tolerance)
- **Live-verified against the production API**: 13 read-only checks (quotes, instrument w/ `exchange_name`, `ALL_SESSIONS` bars incl. 48 real overnight bars, `TWENTY_FOUR_HOURS` preflight accepted, async parity) plus a real fractional order round trip (buy 0.05 VT → `wait_for_fill` → sell → position restored exactly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
